### PR TITLE
Check if temp file exist

### DIFF
--- a/classes/GrcPool/Boinc/ProjectXmlStats/Base.php
+++ b/classes/GrcPool/Boinc/ProjectXmlStats/Base.php
@@ -68,7 +68,7 @@ class GrcPool_Boinc_ProjectXmlStats_Base {
 		if (file_exists($this->feedPath.'user.gz')) {
 			$data = '';
 			$tempFile = $this->basePath.'temp.xml';
-			unlink($tempFile);
+			if(file_exists($tempFile)){unlink($tempFile);}
 
 			$buffer_size = 4096;
 			$out_file_name = $tempFile;


### PR DESCRIPTION
If the temp file does not actually exist, the unlink throws a warning. Can be eliminated with simple "file_exists" check