### PR TITLE
Add table header entry for hardware summary in researcher report

### DIFF
--- a/views/reportResearcher.php
+++ b/views/reportResearcher.php
@@ -6,7 +6,7 @@ $panelContent = '';
 if ($this->view->hosts) {
 	$panelContent .= '
 		<table class="table table-striped table-hover table-condensed">
-			<tr><th>Host</th><th class="text-right">Mag</th></tr>
+			<tr><th>Host</th><th>Hardware</th><th class="text-right">Mag</th></tr>
 	';
 	$magGrandTotal = 0;
 	foreach ($this->view->hosts as $host) {


### PR DESCRIPTION
The researcher report page presents a table with three columns: A description of and link to the host, a summary of its hardware, and its magnitude.

The table header only provides for the host and magnitude, resulting in an incorrect display:
![image](https://user-images.githubusercontent.com/29253356/34083894-ab2284e6-e345-11e7-80b3-48469f3c80af.png)

This is a very small change that simply adds a table header tag for the hardware so that the table formats correctly:

![image](https://user-images.githubusercontent.com/29253356/34083900-be920588-e345-11e7-9b1e-4f4de86c8e8a.png)
